### PR TITLE
Init

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+    "env": {
+        "node": true
+    },
+    "rules": {
+        "quotes": [1, "single"]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs"
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It takes in three arguments [`t` a function that shall be executed to translate 
 ## Installation
 
 ```javascript
-npm install [--save] passport-template-mixins;
+npm install [--save] hmpo-template-mixins;
 ```
 
 ## Usage
@@ -19,7 +19,7 @@ var fields = require('./routes/renew-your-passport/fields');
 
 app.set('view engine', 'html');
 app.set('views', path.join(__dirname, '/views'));
-app.use(require('passport-template-mixins')(i18n.t, fields, { sharedTranslationsKey: 'passport.renew' }));
+app.use(require('hmpo-template-mixins')(i18n.t, fields, { sharedTranslationsKey: 'passport.renew' }));
 
 app.use(function (req, res) {
     // NOTE: res.locals.partials has been set.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # passport-template-mixins
-A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.
+A middleware that exposes a series of Mustache mixins on `res.locals` to ease usage of forms, translations, and some general needs.
+
+Given options containing the `viewsDirectory` path, a `fields` object and a `sharedTranslationsKey` relative key on which to look for field and button translations shall, it shall return a middleware.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,54 @@
 # passport-template-mixins
-A middleware that exposes a series of Mustache mixins on `res.locals` to ease usage of forms, translations, and some general needs.
+A middleware that exposes a series of Mustache mixins on `res.locals` to ease usage of forms, translations, and some other things.
 
-Given options containing the `viewsDirectory` path, a `fields` object and a `sharedTranslationsKey` relative key on which to look for field and button translations shall, it shall return a middleware.
+It takes in three arguments [`t` a function that shall be executed to translate keys into strings of the current locale](https://github.com/i18next/i18next-node), a `fields` object describing config related to the keys that are passed into the mixins that refer to fields, and an options object that has three keys `viewsDirectory` that allows you override the directory that the module checks for partials in (defaults to looking inside the root of this project), `viewEngine` which allows you to alter the file extension of the templates, and `sharedTranslationsKey` which stores a relative key from which to look for field and button translations.
 
-// TODO: We should show an example of the PEX project using this.
-// TODO: We should expose the names of the mixins in the README.md.
+## Installation
+
+```javascript
+npm install [--save] passport-template-mixins;
+```
+
+## Usage
+
+```javascript
+var express = require('express');
+var i18n = require('i18next');
+
+var fields = require('./routes/renew-your-passport/fields');
+
+app.set('view engine', 'html');
+app.set('views', path.join(__dirname, '/views'));
+app.use(require('passport-template-mixins')(i18n.t, fields, { sharedTranslationsKey: 'passport.renew' }));
+
+app.use(function (req, res) {
+    // NOTE: res.locals.partials has been set.
+
+    res.render('example-template');
+});
+```
+
+## Mustache mixins available
+
+```
+t
+time
+selected
+lowercase
+uppercase
+hyphenate
+date
+currency
+select
+input-text
+input-date
+input-text-compound
+input-text-hidden-label
+input-text-postcode
+input-phone
+radio-group
+checkbox
+checkbox-compound
+checkbox-required
+input-submit
+```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 A middleware that exposes a series of Mustache mixins on `res.locals` to ease usage of forms, translations, and some general needs.
 
 Given options containing the `viewsDirectory` path, a `fields` object and a `sharedTranslationsKey` relative key on which to look for field and button translations shall, it shall return a middleware.
+
+// TODO: We should show an example of the PEX project using this.
+// TODO: We should expose the names of the mixins in the README.md.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/template-mixins');

--- a/lib/i18n-property.js
+++ b/lib/i18n-property.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var _ = require('underscore'),
+    Hogan = require('hogan.js');
+
+module.exports = function (t) {
+
+    /**
+     * Given an array of keys and a context iterate through
+     * each of the keys until (1) the translated key is different
+     * from the non-translated key, and (2) a template containing the
+     * data from the context compiles successfully.
+     */
+    return function (keys, context) {
+        if (typeof keys === 'string') {
+            keys = [keys];
+        }
+
+        return _.reduce(keys, function (message, token) {
+            if (!message && i18n.t(token) !== token) {
+                try {
+                    message = Hogan.compile(t(token)).render(context || {});
+                } catch (e) {}
+            }
+            return message;
+        }, null);
+
+    };
+};

--- a/lib/i18n-property.js
+++ b/lib/i18n-property.js
@@ -3,6 +3,9 @@
 var _ = require('underscore'),
     Hogan = require('hogan.js');
 
+// It should be given:
+// - t: a function that will translate a key into the correct language depending
+//      on the locale selected.
 module.exports = function (t) {
 
     /**
@@ -17,7 +20,7 @@ module.exports = function (t) {
         }
 
         return _.reduce(keys, function (message, token) {
-            if (!message && i18n.t(token) !== token) {
+            if (!message && t(token) !== token) {
                 try {
                     message = Hogan.compile(t(token)).render(context || {});
                 } catch (e) {}

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -20,11 +20,12 @@ var Hogan = require('hogan.js'),
 //     the translations.json. Useful for field and button labels.
 module.exports = function (t, fields, options) {
 
+    t = t || _.identity;
+    fields = fields || {};
+
     // This code probably does not need this as the only time it is used
     // only a single key is passed in.
     var i18nLookup = require('./i18n-property')(t);
-
-    fields = fields || {};
 
     var viewsDirectory = options && options.viewsDirectory || path.resolve(__dirname, '../');
     var viewEngine = options && options.viewEngine || 'html';

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -106,17 +106,17 @@ module.exports = function (t, fields, options) {
         };
     }
 
-    function checkbox(key, options) {
-        options = options || {};
-        options.required = options.required || false;
+    function checkbox(key, opts) {
+        opts = opts || {};
+        opts.required = opts.required || false;
         var selected = false;
         if (this.values && this.values[key] !== undefined) {
             selected = this.values[key].toString() === 'true';
         }
-        return _.extend(options, {
+        return _.extend(opts, {
             key: key,
             error: this.errors && this.errors[key],
-            invalid: this.errors && this.errors[key] && options.required,
+            invalid: this.errors && this.errors[key] && opts.required,
             label: t(sharedTranslationsKey + '.fields.' + key + '.label'),
             selected: selected
         });
@@ -193,16 +193,16 @@ module.exports = function (t, fields, options) {
         };
 
         res.locals['checkbox-compound'] = function () {
-            var options = { compound: true };
+            var opts = { compound: true };
             return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, options));
+                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, opts));
             };
         };
 
         res.locals['checkbox-required'] = function () {
-            var options = { required: true };
+            var opts = { required: true };
             return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, options));
+                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, opts));
             };
         };
 

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -7,48 +7,43 @@ var Hogan = require('hogan.js'),
     _ = require('underscore'),
     moment = require('moment');
 
-module.exports = function (t, options) {
+// This returns a middleware that places mixins against the `res.locals` object.
+//
+// It should be given:
+// - t: a function that will translate a key into the correct language depending
+//      on the locale selected.
+// - fields: the data needed to generate mixins options, etc.
+// - options:
+//   - viewDirectory: the folder in which templates are found in.
+//   - viewEngine: the type of view, defaults to 'html'.
+//   - sharedTranslationsKey: used to find translations relatively within
+//     the translations.json. Useful for field and button labels.
+module.exports = function (t, fields, options) {
 
     // This code probably does not need this as the only time it is used
     // only a single key is passed in.
     var i18nLookup = require('./i18n-property')(t);
 
-    // This middleware places template mixins against the `res.locals` object.
+    fields = fields || {};
 
-    // Options contains:
-    // - viewsDirectory: The folder in which the templates are stored is passed in.
-    // - fields: This stores data needed to generate
-    //   a mixin, like the options available or the validation properties.)
-    // - A `sharedTranslationsKey` is also given: this is used to
-    //   find translations relatively within the translation.json
-    //   particularly for field and button labels.
-    var viewsDirectory = options/viewsDirectory || path.resolve(__dirname, '../');
-    var viewEngine = options.viewEngine || 'html';
-    var fields = options.fields || {};
-    var sharedTranslationsKey = options.sharedTranslationsKey || 'shared';
+    var viewsDirectory = options && options.viewsDirectory || path.resolve(__dirname, '../');
+    var viewEngine = options && options.viewEngine || 'html';
+    var sharedTranslationsKey = options && options.sharedTranslationsKey || 'shared';
 
-    var templates = [
+    var PARTIALS = [
         'partials/forms/input-text-group',
         'partials/forms/input-submit',
         'partials/forms/radio-group',
         'partials/forms/select',
         'partials/forms/checkbox'
     ];
-    var compiled = {};
-
-    // TODO: Currently the synchronous compile step happens here and knows its own templates
-    //       already.
-    // TODO: We should allow a user to override the partials locations.
-    // TODO: Separate form related from general from translation related.
-    //
-    // TODO: We should document the code better.
-    // TODO: We should show an example of the PEX project using this.
-    // TODO: We should expose the names of the mixins in the README.md.
-    _.each(templates, function (template) {
+    var compiled = _.chain(PARTIALS).map(function (relativeTemplatePath) {
         var viewExtension = '.' + viewEngine;
-        var templatePath = path.join(viewsDirectory, template + viewExtension);;
-        compiled[template] = Hogan.compile(fs.readFileSync(templatePath).toString());
-    });
+        var templatePath = path.join(viewsDirectory, relativeTemplatePath + viewExtension);
+        var compiledTemplate = Hogan.compile(fs.readFileSync(templatePath).toString());
+
+        return [relativeTemplatePath, compiledTemplate];
+    }).object().value();
 
     function maxlength(key) {
         var validation = fields[key] && fields[key].validate || [];

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -1,0 +1,305 @@
+'use strict';
+
+var fs = require('fs'),
+    path = require('path');
+
+var Hogan = require('hogan.js'),
+    _ = require('underscore'),
+    moment = require('moment');
+
+module.exports = function (t, viewsDirectory, fields, sharedTranslationsKey) {
+
+    // This code probably does not need this as the only time it is used
+    // only a single key is passed in.
+    var i18nLookup = require('./i18n-property')(t);
+
+    // This middleware places template mixins against the `res.locals` object.
+
+    // Options contains:
+    // - viewsDirectory: The folder in which the templates are stored is passed in.
+    // - fields: This stores data needed to generate
+    //   a mixin, like the options available or the validation properties.)
+    // - A `sharedTranslationsKey` is also given: this is used to
+    //   find translations relatively within the translation.json
+    //   particularly for field and button labels.
+    viewsDirectory = viewsDirectory || './views';
+    fields = fields || {};
+    sharedTranslationsKey = sharedTranslationsKey || 'shared';
+
+    var templates = [
+        'partials/forms/input-text-group',
+        'partials/forms/input-submit',
+        'partials/forms/radio-group',
+        'partials/forms/select',
+        'partials/forms/checkbox'
+    ];
+    var compiled = {};
+
+    // TODO: Currently the views extension is assumed.
+    // TODO: Currently the synchronous compile step happens here and knows its own templates
+    //       already.
+    // TODO: We should move the partials into this project.
+    // TODO: We should use an options object to specify the defaults.
+    // TODO: We should allow a user to override the partials locations.
+    // TODO: We should document the code better.
+    // TODO: We should show an example of the PEX project using this.
+    _.each(templates, function (template) {
+        var templatePath = fs.readFileSync(path.join(viewsDirectory, template + '.html'));
+        compiled[template] = Hogan.compile(templatePath.toString());
+    });
+
+    function maxlength(key) {
+        var validation = fields[key] && fields[key].validate || [];
+        var ml = _.findWhere(validation, { type: 'maxlength' }) || _.findWhere(validation, { type: 'exactlength' });
+        if (ml) {
+            return _.isArray(ml.arguments) ? ml.arguments[0] : ml.arguments;
+        } else {
+            return null;
+        }
+    }
+
+    function type(key) {
+        return fields[key] && fields[key].type || 'text';
+    }
+
+    function display(key) {
+        return fields[key] && fields[key].display;
+    }
+
+    function inputText(key, extension) {
+        extension = extension || {};
+        return _.extend(extension, {
+            id: key,
+            type: extension.type || type(key),
+            value: this.values && this.values[key],
+            label: t(sharedTranslationsKey + '.fields.' + key + '.label'),
+            hint: i18nLookup(sharedTranslationsKey + '.fields.' + key + '.hint'),
+            error: this.errors && this.errors[key],
+            maxlength: extension.maxlength || maxlength(key),
+            required: extension.required !== undefined ? extension.required : true,
+            pattern: extension.pattern
+        });
+    }
+
+    function optionGroup(key) {
+        return {
+            key: key,
+            error: this.errors && this.errors[key],
+            options: _.map(fields[key].options, function (label) {
+                var selected = false, value;
+
+                if (typeof label === 'string') {
+                    value = label;
+                } else {
+                    value = label.value;
+                    label = label.label;
+                }
+
+                if (this.values && this.values[key] !== undefined) {
+                    selected = this.values[key] === value;
+                }
+                return {
+                    label: t(label),
+                    value: value,
+                    selected: selected
+                };
+            }, this),
+            display: display(key)
+        };
+    }
+
+    function checkbox(key, options) {
+        options = options || {};
+        options.required = options.required || false;
+        var selected = false;
+        if (this.values && this.values[key] !== undefined) {
+            selected = this.values[key].toString() === 'true';
+        }
+        return _.extend(options, {
+            key: key,
+            error: this.errors && this.errors[key],
+            invalid: this.errors && this.errors[key] && options.required,
+            label: t(sharedTranslationsKey + '.fields.' + key + '.label'),
+            selected: selected
+        });
+    }
+
+    return function (req, res, next) {
+
+        res.locals['input-text'] = function () {
+            return function (key) {
+                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key));
+            };
+        };
+
+        res.locals['input-date'] = function () {
+            return function (key) {
+                var parts = [
+                    compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, class: 'date-input' })),
+                    compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, class: 'date-input' })),
+                    compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, class: 'date-input' }))
+                ];
+                return parts.join('\n');
+            };
+        };
+
+        res.locals['input-text-compound'] = function () {
+            return function (key) {
+                var obj = { compound: true };
+                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
+            };
+        };
+
+        res.locals['input-text-hidden-label'] = function () {
+            return function (key) {
+                var obj = {
+                    hiddenLabel: true,
+                    required: false
+                };
+                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
+            };
+        };
+
+        res.locals['input-text-postcode'] = function () {
+            return function (key) {
+                var obj = {
+                    postcode: true,
+                    class: 'uppercase'
+                };
+                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
+            };
+        };
+
+        res.locals['input-phone'] = function () {
+            return function (key) {
+                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { maxlength: 18 }));
+            };
+        };
+
+        res.locals['radio-group'] = function () {
+            return function (key) {
+                return compiled['partials/forms/radio-group'].render(optionGroup.call(this, key));
+            };
+        };
+
+        res.locals.select = function () {
+            return function (key) {
+                return compiled['partials/forms/select'].render(inputText.call(this, key, optionGroup.call(this, key)));
+            };
+        };
+
+        res.locals.checkbox = function () {
+            return function (key) {
+                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key));
+            };
+        };
+
+        res.locals['checkbox-compound'] = function () {
+            var options = { compound: true };
+            return function (key) {
+                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, options));
+            };
+        };
+
+        res.locals['checkbox-required'] = function () {
+            var options = { required: true };
+            return function (key) {
+                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, options));
+            };
+        };
+
+        /**
+        * props: '[value] [id]'
+        */
+        res.locals['input-submit'] = function () {
+            return function (props) {
+                props = props.split(' ');
+                var def = 'next',
+                    value = props[0] || def,
+                    id = props[1];
+
+                var obj = {
+                    value: t(sharedTranslationsKey + '.buttons.' + value),
+                    id: id
+                };
+                return compiled['partials/forms/input-submit'].render(obj);
+            };
+        };
+
+        res.locals.currency = function () {
+            return function (txt) {
+                var value = parseFloat(Hogan.compile(txt).render(this));
+                if (isNaN(value)) {
+                    return txt;
+                } else if (value % 1 === 0) {
+                    value = value.toString();
+                } else {
+                    value = value.toFixed(2);
+                }
+                return '£' + value;
+            };
+        };
+
+        res.locals.date = function () {
+            return function (txt) {
+                var value = Hogan.compile(txt).render(this);
+                return moment(value).format('D MMMM YYYY');
+            };
+        };
+
+        res.locals.hyphenate = function () {
+            return function (txt) {
+                txt = txt || '';
+                return Hogan.compile(txt).render(this).toLowerCase().replace(' ', '-');
+            };
+        };
+
+        res.locals.uppercase = function () {
+            return function (txt) {
+                txt = txt || '';
+                return Hogan.compile(txt).render(this).toUpperCase();
+            };
+        };
+
+        res.locals.lowercase = function () {
+            return function (txt) {
+                txt = txt || '';
+                return Hogan.compile(txt).render(this).toLowerCase();
+            };
+        };
+
+        res.locals.selected = function () {
+            return function (txt) {
+                var bits = txt.split('='),
+                    val;
+                if (this.values && this.values[bits[0]] !== undefined) {
+                    val = this.values[bits[0]].toString();
+                }
+                return val === bits[1] ? ' checked="checked"' : '';
+            };
+        };
+
+        /**
+        * Use on whole sentences
+        */
+        res.locals.time = function () {
+            return function (txt) {
+                txt = txt || '';
+                txt = Hogan.compile(txt).render(this);
+                txt = txt.replace(/12:00am/i, 'midnight').replace(/^midnight/, 'Midnight');
+                txt = txt.replace(/12:00pm/i, 'midday').replace(/^middday/, 'Midday');
+                return txt;
+            };
+        };
+
+        res.locals.t = function () {
+            return function (txt) {
+                txt = Hogan.compile(txt).render(this);
+                return t.apply(req, [txt, this]);
+            };
+        };
+
+        next();
+    };
+
+};

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -22,7 +22,7 @@ module.exports = function (t, viewsDirectory, fields, sharedTranslationsKey) {
     // - A `sharedTranslationsKey` is also given: this is used to
     //   find translations relatively within the translation.json
     //   particularly for field and button labels.
-    viewsDirectory = viewsDirectory || './views';
+    viewsDirectory = viewsDirectory || path.resolve(__dirname, '../');
     fields = fields || {};
     sharedTranslationsKey = sharedTranslationsKey || 'shared';
 
@@ -38,14 +38,16 @@ module.exports = function (t, viewsDirectory, fields, sharedTranslationsKey) {
     // TODO: Currently the views extension is assumed.
     // TODO: Currently the synchronous compile step happens here and knows its own templates
     //       already.
-    // TODO: We should move the partials into this project.
     // TODO: We should use an options object to specify the defaults.
     // TODO: We should allow a user to override the partials locations.
     // TODO: We should document the code better.
     // TODO: We should show an example of the PEX project using this.
+    // TODO: We should expose the names of the mixins in the README.md.
+    // TODO: Simplify the interface.
+    // TODO: Separate form related from general from translation related.
     _.each(templates, function (template) {
-        var templatePath = fs.readFileSync(path.join(viewsDirectory, template + '.html'));
-        compiled[template] = Hogan.compile(templatePath.toString());
+        var templatePath = path.join(viewsDirectory, template + '.html');;
+        compiled[template] = Hogan.compile(fs.readFileSync(templatePath).toString());
     });
 
     function maxlength(key) {

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -7,7 +7,7 @@ var Hogan = require('hogan.js'),
     _ = require('underscore'),
     moment = require('moment');
 
-module.exports = function (t, viewsDirectory, fields, sharedTranslationsKey) {
+module.exports = function (t, options) {
 
     // This code probably does not need this as the only time it is used
     // only a single key is passed in.
@@ -22,9 +22,10 @@ module.exports = function (t, viewsDirectory, fields, sharedTranslationsKey) {
     // - A `sharedTranslationsKey` is also given: this is used to
     //   find translations relatively within the translation.json
     //   particularly for field and button labels.
-    viewsDirectory = viewsDirectory || path.resolve(__dirname, '../');
-    fields = fields || {};
-    sharedTranslationsKey = sharedTranslationsKey || 'shared';
+    var viewsDirectory = options/viewsDirectory || path.resolve(__dirname, '../');
+    var viewEngine = options.viewEngine || 'html';
+    var fields = options.fields || {};
+    var sharedTranslationsKey = options.sharedTranslationsKey || 'shared';
 
     var templates = [
         'partials/forms/input-text-group',
@@ -35,18 +36,17 @@ module.exports = function (t, viewsDirectory, fields, sharedTranslationsKey) {
     ];
     var compiled = {};
 
-    // TODO: Currently the views extension is assumed.
     // TODO: Currently the synchronous compile step happens here and knows its own templates
     //       already.
-    // TODO: We should use an options object to specify the defaults.
     // TODO: We should allow a user to override the partials locations.
+    // TODO: Separate form related from general from translation related.
+    //
     // TODO: We should document the code better.
     // TODO: We should show an example of the PEX project using this.
     // TODO: We should expose the names of the mixins in the README.md.
-    // TODO: Simplify the interface.
-    // TODO: Separate form related from general from translation related.
     _.each(templates, function (template) {
-        var templatePath = path.join(viewsDirectory, template + '.html');;
+        var viewExtension = '.' + viewEngine;
+        var templatePath = path.join(viewsDirectory, template + viewExtension);;
         compiled[template] = Hogan.compile(fs.readFileSync(templatePath).toString());
     });
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "passport-template-mixins",
+  "name": "hmpo-template-mixins",
   "version": "0.0.0",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "passport-template-mixins",
+  "version": "0.0.0",
+  "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UKHomeOffice/passport-template-mixins.git"
+  },
+  "keywords": [
+    "middleware",
+    "express",
+    "partials",
+    "hogan",
+    "mustache",
+    "form",
+    "translations",
+    "general"
+  ],
+  "author": "Seb Insua",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/UKHomeOffice/passport-template-mixins/issues"
+  },
+  "homepage": "https://github.com/UKHomeOffice/passport-template-mixins",
+  "dependencies": {
+    "hogan.js": "^3.0.2",
+    "moment": "^2.9.0",
+    "underscore": "^1.7.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "hmpo-template-mixins",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run lint",
+    "lint": "./node_modules/.bin/eslint ."
   },
   "repository": {
     "type": "git",
@@ -30,5 +31,8 @@
     "hogan.js": "^3.0.2",
     "moment": "^2.9.0",
     "underscore": "^1.7.0"
+  },
+  "devDependencies": {
+    "eslint": "^0.14.1"
   }
 }

--- a/partials/forms/checkbox.html
+++ b/partials/forms/checkbox.html
@@ -1,0 +1,6 @@
+<div id="{{key}}-group" class="form-group{{#compound}}-compound{{/compound}}{{#error}} validation-error{{/error}}">
+    <label for="{{key}}" class="block-label{{#invalid}} invalid-input{{/invalid}}">
+        <input type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{^error}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
+        {{{label}}}
+    </label>
+</div>

--- a/partials/forms/input-submit.html
+++ b/partials/forms/input-submit.html
@@ -1,0 +1,1 @@
+<input type="submit" {{#id}}id="{{id}}"{{/id}} value="{{{value}}}" class="button">

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,0 +1,5 @@
+<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
+    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
+    {{#hint}}<p class="form-hint">{{hint}}</p>{{/hint}}
+    <input type="{{type}}" id="{{id}}" class="form-control{{#class}} {{class}}{{/class}}{{#postcode}} postcode{{/postcode}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}} aria-required="{{required}}">
+</div>

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,0 +1,8 @@
+<div id="{{key}}-group" class="form-group{{#display}} {{display}}{{/display}}{{#error}} validation-error{{/error}}">
+    {{#options}}
+        <label class="block-label" for="{{key}}-{{value}}">
+            <input type="radio" name="{{key}}" id="{{key}}-{{value}}" value="{{value}}" aria-required="true"{{#selected}} checked="checked"{{/selected}}>
+            {{{label}}}
+        </label>
+    {{/options}}
+</div>

--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -1,0 +1,8 @@
+<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
+    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
+    <select id="{{id}}" class="{{#class}}{{class}}{{/class}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
+    {{#options}}
+        <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
+    {{/options}}
+    </select>
+</div>


### PR DESCRIPTION
I have attempted to move across the mixins relating to forms and some other things.

A couple of thoughts:

1. In PEX the fields and buttons were all assumed to have translation keys inside 'passport.renew'. The default is now 'shared', but you can alter it by passing in `options.sharedTranslationsKey`.
2. Requiring the i18next module directly in the package caused it to not load translations. Presumably it ends up pointing to the wrong translations.json though I did not investigate deeply. What I did instead was to let you to pass in a `i18n.t` as the first argument. I think this is better anyway - and you are no longer coupled to a translation library as it defaults to `_.identity`.
3. I move the form partials into this project as the logic is strongly coupled to these templates and it would not make sense for it to be unusable without configuring templates in your own code. That means we can't change the templates easily as we will be sharing them. Or if we do wish to change them, we'll have to alter `options.viewsDirectory` so that the library finds our own 'partials/forms' directory within - messy so probably you should never do that.
4. I noticed that the only time i18nLookup was used in this module it probably didn't need to be used. However, I didn't change it.
5. It might at some point be possible to separate the logic for the different kinds of mixins a little bit - currently it's all in one file. A nice refactor might be to store definitions of mixins like `{ mixinName: 'input-text', handler: inputText, partialPath: 'partials/forms/input-text-group' }`. Later on this would allow us to load groups of mixins into the middleware.
