### PR TITLE
Allow for translation keys to not be namespaced

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/spec.*

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -29,7 +29,11 @@ module.exports = function (t, fields, options) {
 
     var viewsDirectory = options && options.viewsDirectory || path.resolve(__dirname, '../');
     var viewEngine = options && options.viewEngine || 'html';
-    var sharedTranslationsKey = options && options.sharedTranslationsKey || 'shared';
+    var sharedTranslationsKey = options && options.sharedTranslationsKey || '';
+
+    if (sharedTranslationsKey && !sharedTranslationsKey.match(/\.$/)) {
+        sharedTranslationsKey += '.';
+    }
 
     var PARTIALS = [
         'partials/forms/input-text-group',
@@ -70,8 +74,8 @@ module.exports = function (t, fields, options) {
             id: key,
             type: extension.type || type(key),
             value: this.values && this.values[key],
-            label: t(sharedTranslationsKey + '.fields.' + key + '.label'),
-            hint: i18nLookup(sharedTranslationsKey + '.fields.' + key + '.hint'),
+            label: t(sharedTranslationsKey + 'fields.' + key + '.label'),
+            hint: i18nLookup(sharedTranslationsKey + 'fields.' + key + '.hint'),
             error: this.errors && this.errors[key],
             maxlength: extension.maxlength || maxlength(key),
             required: extension.required !== undefined ? extension.required : true,
@@ -117,7 +121,7 @@ module.exports = function (t, fields, options) {
             key: key,
             error: this.errors && this.errors[key],
             invalid: this.errors && this.errors[key] && opts.required,
-            label: t(sharedTranslationsKey + '.fields.' + key + '.label'),
+            label: t(sharedTranslationsKey + 'fields.' + key + '.label'),
             selected: selected
         });
     }
@@ -211,13 +215,13 @@ module.exports = function (t, fields, options) {
         */
         res.locals['input-submit'] = function () {
             return function (props) {
-                props = props.split(' ');
+                props = (props || '').split(' ');
                 var def = 'next',
                     value = props[0] || def,
                     id = props[1];
 
                 var obj = {
-                    value: t(sharedTranslationsKey + '.buttons.' + value),
+                    value: t(sharedTranslationsKey + 'buttons.' + value),
                     id: id
                 };
                 return compiled['partials/forms/input-submit'].render(obj);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-template-mixins",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint",
-    "lint": "./node_modules/.bin/eslint ."
+    "test": "npm run lint && npm run unit",
+    "lint": "eslint .",
+    "unit": "mocha test/. --require ./test/helpers.js --recursive"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,10 @@
     "underscore": "^1.7.0"
   },
   "devDependencies": {
-    "eslint": "^0.14.1"
+    "chai": "^2.1.0",
+    "eslint": "^0.14.1",
+    "mocha": "^2.1.0",
+    "sinon": "^1.12.2",
+    "sinon-chai": "^2.7.0"
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,6 @@
+var chai = require('chai');
+
+global.should = chai.should();
+global.expect = chai.expect;
+global.sinon = require('sinon');
+chai.use(require('sinon-chai'));

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1,0 +1,117 @@
+var mixins = require('../lib/template-mixins');
+
+var Hogan = require('hogan.js');
+
+function translate(key) {
+    return key;
+}
+
+describe('Template Mixins', function () {
+
+    var req, res, next, render, middleware;
+
+    beforeEach(function () {
+        req = {};
+        res = {
+            locals: {}
+        };
+        next = sinon.stub();
+        render = sinon.stub();
+        sinon.stub(Hogan, 'compile').returns({
+            render: render
+        });
+    });
+
+    afterEach(function () {
+        Hogan.compile.restore();
+    });
+
+    it('returns a middleware', function () {
+        mixins().should.be.a('function');
+        mixins().length.should.equal(3);
+    });
+
+    it('calls next', function () {
+        mixins()(req, res, next);
+        next.should.have.been.calledOnce;
+    });
+
+    describe('input-text', function () {
+
+        beforeEach(function () {
+            middleware = mixins(translate, {});
+        });
+
+        it('adds a function to res.locals', function () {
+            middleware(req, res, next);
+            res.locals['input-text'].should.be.a('function');
+        });
+
+        it('returns a function', function () {
+            middleware(req, res, next);
+            res.locals['input-text']().should.be.a('function');
+        });
+
+        it('looks up field label', function () {
+            middleware(req, res, next);
+            res.locals['input-text']().call(res.locals, 'field-name');
+            render.should.have.been.calledWith(sinon.match({
+                label: 'fields.field-name.label'
+            }));
+        });
+
+        it('prefixes translation lookup with namespace if provided', function () {
+            middleware = mixins(translate, {}, { sharedTranslationsKey: 'name.space' });
+            middleware(req, res, next);
+            res.locals['input-text']().call(res.locals, 'field-name');
+            render.should.have.been.calledWith(sinon.match({
+                label: 'name.space.fields.field-name.label'
+            }));
+        });
+
+    });
+
+    describe('input-submit', function () {
+
+        beforeEach(function () {
+            middleware = mixins(translate, {});
+        });
+
+        it('adds a function to res.locals', function () {
+            middleware(req, res, next);
+            res.locals['input-submit'].should.be.a('function');
+        });
+
+        it('returns a function', function () {
+            middleware(req, res, next);
+            res.locals['input-submit']().should.be.a('function');
+        });
+
+        it('looks up button value with default key of "next"', function () {
+            middleware(req, res, next);
+            res.locals['input-submit']().call(res.locals);
+            render.should.have.been.calledWith(sinon.match({
+                value: 'buttons.next'
+            }));
+        });
+
+        it('looks up button value with key if provided', function () {
+            middleware(req, res, next);
+            res.locals['input-submit']().call(res.locals, 'button-id');
+            render.should.have.been.calledWith(sinon.match({
+                value: 'buttons.button-id'
+            }));
+        });
+
+        it('prefixes translation lookup with namespace if provided', function () {
+            middleware = mixins(translate, {}, { sharedTranslationsKey: 'name.space' });
+            middleware(req, res, next);
+            res.locals['input-submit']().call(res.locals, 'button-id');
+            render.should.have.been.calledWith(sinon.match({
+                value: 'name.space.buttons.button-id'
+            }));
+        });
+
+    });
+
+});


### PR DESCRIPTION
I want to be able to define a minimum translation file structure, which means that I should be able to have `fields` and `buttons` properties at the top level. So default to a shared translation namespace of '' instead of 'shared'.

Add some tests for this as well. Tests are obviously short of full coverage, but they're a start.

Bump a minor version as well.