### PR TITLE
A date field may be marked as 'inexact' in order for only the month and year fields to be created.

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -136,11 +136,21 @@ module.exports = function (t, fields, options) {
 
         res.locals['input-date'] = function () {
             return function (key) {
-                var parts = [
-                    compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, class: 'date-input' })),
-                    compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, class: 'date-input' })),
-                    compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, class: 'date-input' }))
-                ];
+                // Exact unless there is a inexact property against the fields key.
+                var isExact = fields[key] ? fields[key].inexact !== true : true;
+
+                var parts = [],
+                    dayPart, monthPart, yearPart;
+
+                if (isExact) {
+                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, class: 'date-input' }));
+                    parts.push(dayPart);
+                }
+
+                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, class: 'date-input' }));
+                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, class: 'date-input' }));
+                parts = parts.concat(monthPart, yearPart);
+
                 return parts.join('\n');
             };
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-template-mixins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-template-mixins",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -71,6 +71,150 @@ describe('Template Mixins', function () {
 
     });
 
+    describe('input-date', function () {
+
+        beforeEach(function () {
+            middleware = mixins(translate, {});
+        });
+
+        it('adds a function to res.locals', function () {
+            middleware(req, res, next);
+            res.locals['input-date'].should.be.a('function');
+        });
+
+        it('returns a function', function () {
+            middleware(req, res, next);
+            res.locals['input-date']().should.be.a('function');
+        });
+
+        it('renders thrice if the field is not marked as inexact', function () {
+            middleware(req, res, next);
+            res.locals['input-date']().call(res.locals, 'field-name');
+            render.should.have.been.calledThrice;
+        });
+
+        it('renders twice if the field is marked as inexact', function () {
+            var middlewareWithFieldNameMarkedAsInexact = mixins(translate, {
+                'field-name': {
+                    'inexact': true
+                }
+            });
+            middlewareWithFieldNameMarkedAsInexact(req, res, next);
+            res.locals['input-date']().call(res.locals, 'field-name');
+            render.should.have.been.calledTwice;
+        });
+
+        it('looks up field label', function () {
+            middleware(req, res, next);
+            res.locals['input-date']().call(res.locals, 'field-name');
+
+            render.called;
+
+            var dayCall = render.getCall(0),
+                monthCall = render.getCall(1),
+                yearCall = render.getCall(2);
+
+            dayCall.calledWith(sinon.match({
+              'class': 'date-input',
+              error: undefined,
+              hint: null,
+              id: 'field-name-day',
+              label: 'fields.field-name-day.label',
+              max: 31,
+              maxlength: 2,
+              min: 1,
+              pattern: '[0-9]*',
+              required: true,
+              type: 'text',
+              value: undefined
+            })).should.be.true;
+
+            monthCall.calledWith(sinon.match({
+              pattern: '[0-9]*',
+              min: 1,
+              max: 12,
+              maxlength: 2,
+              'class': 'date-input',
+              id: 'field-name-month',
+              type: 'text',
+              value: undefined,
+              label: 'fields.field-name-month.label',
+              hint: null,
+              error: undefined,
+              required: true
+            })).should.be.true;
+
+            yearCall.calledWith(sinon.match({
+              pattern: '[0-9]*',
+              maxlength: 4,
+              'class': 'date-input',
+              id: 'field-name-year',
+              type: 'text',
+              value: undefined,
+              label: 'fields.field-name-year.label',
+              hint: null,
+              error: undefined,
+              required: true
+            })).should.be.true;
+        });
+
+        it('prefixes translation lookup with namespace if provided', function () {
+            middleware = mixins(translate, {}, { sharedTranslationsKey: 'name.space' });
+            middleware(req, res, next);
+            res.locals['input-date']().call(res.locals, 'field-name');
+
+            render.called;
+
+            var dayCall = render.getCall(0),
+                monthCall = render.getCall(1),
+                yearCall = render.getCall(2);
+
+            dayCall.calledWith(sinon.match({
+              'class': 'date-input',
+              error: undefined,
+              hint: null,
+              id: 'field-name-day',
+              label: 'name.space.fields.field-name-day.label',
+              max: 31,
+              maxlength: 2,
+              min: 1,
+              pattern: '[0-9]*',
+              required: true,
+              type: 'text',
+              value: undefined
+            })).should.be.true;
+
+            monthCall.calledWith(sinon.match({
+              pattern: '[0-9]*',
+              min: 1,
+              max: 12,
+              maxlength: 2,
+              'class': 'date-input',
+              id: 'field-name-month',
+              type: 'text',
+              value: undefined,
+              label: 'name.space.fields.field-name-month.label',
+              hint: null,
+              error: undefined,
+              required: true
+            })).should.be.true;
+
+            yearCall.calledWith(sinon.match({
+              pattern: '[0-9]*',
+              maxlength: 4,
+              'class': 'date-input',
+              id: 'field-name-year',
+              type: 'text',
+              value: undefined,
+              label: 'name.space.fields.field-name-year.label',
+              hint: null,
+              error: undefined,
+              required: true
+            })).should.be.true;
+        });
+
+    });
+
     describe('input-submit', function () {
 
         beforeEach(function () {

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -114,48 +114,17 @@ describe('Template Mixins', function () {
                 monthCall = render.getCall(1),
                 yearCall = render.getCall(2);
 
-            dayCall.calledWith(sinon.match({
-              'class': 'date-input',
-              error: undefined,
-              hint: null,
-              id: 'field-name-day',
-              label: 'fields.field-name-day.label',
-              max: 31,
-              maxlength: 2,
-              min: 1,
-              pattern: '[0-9]*',
-              required: true,
-              type: 'text',
-              value: undefined
-            })).should.be.true;
+            dayCall.should.have.been.calledWith(sinon.match({
+              label: 'fields.field-name-day.label'
+            }));
 
-            monthCall.calledWith(sinon.match({
-              pattern: '[0-9]*',
-              min: 1,
-              max: 12,
-              maxlength: 2,
-              'class': 'date-input',
-              id: 'field-name-month',
-              type: 'text',
-              value: undefined,
-              label: 'fields.field-name-month.label',
-              hint: null,
-              error: undefined,
-              required: true
-            })).should.be.true;
+            monthCall.should.have.been.calledWith(sinon.match({
+              label: 'fields.field-name-month.label'
+            }));
 
-            yearCall.calledWith(sinon.match({
-              pattern: '[0-9]*',
-              maxlength: 4,
-              'class': 'date-input',
-              id: 'field-name-year',
-              type: 'text',
-              value: undefined,
-              label: 'fields.field-name-year.label',
-              hint: null,
-              error: undefined,
-              required: true
-            })).should.be.true;
+            yearCall.should.have.been.calledWith(sinon.match({
+              label: 'fields.field-name-year.label'
+            }));
         });
 
         it('prefixes translation lookup with namespace if provided', function () {
@@ -169,48 +138,17 @@ describe('Template Mixins', function () {
                 monthCall = render.getCall(1),
                 yearCall = render.getCall(2);
 
-            dayCall.calledWith(sinon.match({
-              'class': 'date-input',
-              error: undefined,
-              hint: null,
-              id: 'field-name-day',
-              label: 'name.space.fields.field-name-day.label',
-              max: 31,
-              maxlength: 2,
-              min: 1,
-              pattern: '[0-9]*',
-              required: true,
-              type: 'text',
-              value: undefined
-            })).should.be.true;
+            dayCall.should.have.been.calledWith(sinon.match({
+              label: 'name.space.fields.field-name-day.label'
+            }));
 
-            monthCall.calledWith(sinon.match({
-              pattern: '[0-9]*',
-              min: 1,
-              max: 12,
-              maxlength: 2,
-              'class': 'date-input',
-              id: 'field-name-month',
-              type: 'text',
-              value: undefined,
-              label: 'name.space.fields.field-name-month.label',
-              hint: null,
-              error: undefined,
-              required: true
-            })).should.be.true;
+            monthCall.should.have.been.calledWith(sinon.match({
+              label: 'name.space.fields.field-name-month.label'
+            }));
 
-            yearCall.calledWith(sinon.match({
-              pattern: '[0-9]*',
-              maxlength: 4,
-              'class': 'date-input',
-              id: 'field-name-year',
-              type: 'text',
-              value: undefined,
-              label: 'name.space.fields.field-name-year.label',
-              hint: null,
-              error: undefined,
-              required: true
-            })).should.be.true;
+            yearCall.should.have.been.calledWith(sinon.match({
+              label: 'name.space.fields.field-name-year.label'
+            }));
         });
 
     });


### PR DESCRIPTION
A date field may be marked as 'inexact' in order for only the month and year fields to be created.

By default date fields are considered exact - and therefore the original behaviour of showing day month year is kept.

Thoughts?