### PR TITLE
Publish i18n-lookup code as a separate module

### DIFF
--- a/lib/i18n-property.js
+++ b/lib/i18n-property.js
@@ -1,32 +1,13 @@
 'use strict';
 
-var _ = require('underscore'),
+var lookup = require('i18n-lookup'),
     Hogan = require('hogan.js');
 
 // It should be given:
 // - t: a function that will translate a key into the correct language depending
 //      on the locale selected.
 module.exports = function (t) {
-
-    /**
-     * Given an array of keys and a context iterate through
-     * each of the keys until (1) the translated key is different
-     * from the non-translated key, and (2) a template containing the
-     * data from the context compiles successfully.
-     */
-    return function (keys, context) {
-        if (typeof keys === 'string') {
-            keys = [keys];
-        }
-
-        return _.reduce(keys, function (message, token) {
-            if (!message && t(token) !== token) {
-                try {
-                    message = Hogan.compile(t(token)).render(context || {});
-                } catch (e) {}
-            }
-            return message;
-        }, null);
-
-    };
+    return lookup(t, function (template, context) {
+        return Hogan.compile(template).render(context);
+    });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-template-mixins",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/UKHomeOffice/passport-template-mixins",
   "dependencies": {
     "hogan.js": "^3.0.2",
+    "i18n-lookup": "^0.1.0",
     "moment": "^2.9.0",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
We want to re-use the same functionality elsewhere, so split this code into it's own module.

Code for that module is at https://github.com/UKHomeOffice/i18n-lookup